### PR TITLE
GNOME 3.38 and other minor elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build-dir/
+.flatpak-builder/

--- a/com.github.tchx84.Flatseal.json
+++ b/com.github.tchx84.Flatseal.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.tchx84.Flatseal",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "com.github.tchx84.Flatseal",

--- a/com.github.tchx84.Flatseal.json
+++ b/com.github.tchx84.Flatseal.json
@@ -44,7 +44,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://source.puri.sm/Librem5/libhandy/-/archive/v0.0.13/libhandy-v0.0.13.tar.gz",
+                    "url": "https://gitlab.gnome.org/GNOME/libhandy/-/archive/v0.0.13/libhandy-v0.0.13.tar.gz",
                     "sha256": "138bec94e66d15a7a19350b65845d4529bcd969ea913ab3eb438f56fe47d5d37"
                 }
             ]
@@ -53,22 +53,22 @@
             "name": "appstream-glib",
             "buildsystem": "meson",
             "config-opts": [
-		"-Ddep11=false",
-		"-Dbuilder=false",
-		"-Drpm=false",
-		"-Dalpm=false",
-		"-Dfonts=false",
-		"-Dstemmer=false",
-		"-Dman=false",
-		"-Dstemmer=false",
-		"-Dgtk-doc=false",
-		"-Dintrospection=true"
+                "-Ddep11=false",
+                "-Dbuilder=false",
+                "-Drpm=false",
+                "-Dalpm=false",
+                "-Dfonts=false",
+                "-Dstemmer=false",
+                "-Dman=false",
+                "-Dstemmer=false",
+                "-Dgtk-doc=false",
+                "-Dintrospection=true"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/hughsie/appstream-glib/archive/appstream_glib_0_7_17.tar.gz",
-                    "sha256": "cb612c9e634275e574fa639737cf63711358cd10b9d0d377f70025653fefdd16"
+                    "url": "https://github.com/hughsie/appstream-glib/archive/appstream_glib_0_7_18.tar.gz",
+                    "sha256": "73b8c10273c4cdd8f6de03c2524fedad64e34ccae08ee847dba804bb15461f6e"
                 }
             ]
         },


### PR DESCRIPTION
- Add .gitignore
- Update runtime to GNOME 3.38
- Update dependencies
