### PR TITLE
chore: add x-checker-data metadata for automated flathub bot PRs

### DIFF
--- a/com.github.tchx84.Flatseal.json
+++ b/com.github.tchx84.Flatseal.json
@@ -36,7 +36,11 @@
                     "type": "git",
                     "url": "https://github.com/tchx84/Flatseal.git",
                     "tag": "v2.4.0",
-                    "commit": "4d34c0c3006ac5e80a0e61b6e073f010aba44179"
+                    "commit": "4d34c0c3006ac5e80a0e61b6e073f010aba44179",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Allows the flatseal sources to be updated automatically via PRs from the Flathub automation bot (or other automation tools)

<img width="1399" height="706" alt="image" src="https://github.com/user-attachments/assets/339722f5-1256-486e-be61-21bce83718af" />